### PR TITLE
Fix playSound()

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,3 @@ If you want to suggest a feature, open an issue.
 ## Known Bugs
 
 These are bugs, both major and minor, that I am aware of and working on fixing. This could be another good place to get started if you are looking to contribute.
-
-- playSound() doesn't compile correctly for some reason.

--- a/example/game.cpp
+++ b/example/game.cpp
@@ -120,7 +120,7 @@ void Step(){
 	if(Player.Collided(Ball) && Player.isActive()){
 		Player.Destroy();
 		alive = false;
-		playSound("assets/destroy.wav", -1);
+		playSound("assets/destroy.wav");
 	}
 }
 

--- a/feather/sound.cpp
+++ b/feather/sound.cpp
@@ -17,7 +17,7 @@ int resumeMusic(){
 	return 0;
 }
 
-/* int playSound(const char *soundPath){ */
-/* 	Mix_PlayChannel(-1, Mix_LoadWAV(soundPath), 0); */
-/* 	return 0; */
-/* } */
+int playSound(const char *soundPath){
+ 	Mix_PlayChannel(-1, Mix_LoadWAV(soundPath), 0);
+ 	return 0;
+}

--- a/feather/sound.h
+++ b/feather/sound.h
@@ -9,6 +9,6 @@ int swapMusic(const char *musicPath);
 int pauseMusic();
 int resumeMusic();
 
-/* int playSound(const char *soundPath); */
+int playSound(const char *soundPath);
 
 #endif


### PR DESCRIPTION
playSound didn't compile in example/game.cpp because an extra argument(-1) was provided to it, this has now been removed and it compiles.
The readme has also been updated to reflect this change.
