### PR TITLE
Added some basic rotation to the Entity class

### DIFF
--- a/feather/entity.cpp
+++ b/feather/entity.cpp
@@ -29,7 +29,7 @@ int Entity::swapSprite(const char *spritePath){
 int Entity::Draw(){
 	if(active){
 		SDL_Rect dst = { transform.position.x, transform.position.y, transform.scale.x, transform.scale.y };
-		SDL_RenderCopy(rend, sprite, NULL, &dst);
+		SDL_RenderCopyEx(rend, sprite, NULL, &dst, angle, NULL, SDL_FLIP_NONE);
 	}
 	return 0;
 }
@@ -55,6 +55,7 @@ int Entity::Create(const char *spritePath, int x, int y, int width, int height){
 	transform.position.y = y;
 	transform.scale.x = width;
 	transform.scale.y = height;
+	angle = 0.0;
 	active = true;
 	id = currentID;
 	entityTracker[id] = this;
@@ -74,6 +75,7 @@ int Entity::Create(const char *spritePath, Vector position, Vector scale){
 	transform.position.y = position.y;
 	transform.scale.x = scale.x;
 	transform.scale.y = scale.y;
+	angle = 0.0;
 	active = true;
 	id = currentID;
 	entityTracker[id] = this;

--- a/feather/entity.h
+++ b/feather/entity.h
@@ -11,6 +11,7 @@ class Entity {
 	public:
 		Transform transform;
 		int id;
+		double angle;
 
 		bool isActive();
 


### PR DESCRIPTION
Entity has a new member:
![image](https://user-images.githubusercontent.com/62521534/193992412-3a2a38c8-3667-4b24-8fa2-6c82b3973882.png)

And the draw function uses the RenderCopyEx() with the rotation parameter:
![image](https://user-images.githubusercontent.com/62521534/193992549-d15dafd0-4630-4c66-8d7e-312548a586cd.png)

Additionally, Create() simply initializes this rotation at zero. Maybe at some point add angle as a parameter? We could add a version without it so it defaults to 0.0 when it is not needed.