### PR TITLE
Fixed font not loading #35

### DIFF
--- a/feather/main.cpp
+++ b/feather/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv){
 	}
 	std::cout << "Rendering context created" << std::endl;
 
-	font = TTF_OpenFont("feather/FreeSans.ttf", 25);
+	font = TTF_OpenFont("../feather/FreeSans.ttf", 25);
 	std::cout << "Font loaded" << std::endl;
 
 	srand((unsigned) time(0));


### PR DESCRIPTION
The font global was showing up as null due to not being able to find the directory. Just added ../ and it works now.
![image](https://user-images.githubusercontent.com/62521534/194963514-0ea0a447-7ab6-42e6-a9c5-708f94d47a6e.png)
