### PR TITLE
Small improvement to collision

### DIFF
--- a/feather/rigidentity.cpp
+++ b/feather/rigidentity.cpp
@@ -12,20 +12,9 @@ int RigidEntity::Update(float deltaTime) {
 	force.y = 0;
 
 	velocity += acceleration * time * 200;	
-	transform.position += velocity * time;
+	Vector delta = velocity * time;
 
-	//Collision
-	for (auto element : entityTracker) {
-		if (dynamic_cast<RigidEntity*>(element.second)) {
-			RigidEntity* rigidEntity = dynamic_cast<RigidEntity*>(element.second);
-			SDL_Rect dst1 = { transform.position.x, transform.position.y, transform.scale.x, transform.scale.y };
-			SDL_Rect dst2 = { rigidEntity->transform.position.x, rigidEntity->transform.position.y, rigidEntity->transform.scale.x, rigidEntity->transform.scale.y };
-			if (SDL_HasIntersection(&dst1, &dst2)) {
-				Vector move(dst1.x - dst2.x, dst1.y - dst2.y);
-				transform.position += move * 0.2;
-			}
-		}
-	}
+	testMove(delta);
 
 	return 0;
 }
@@ -57,4 +46,21 @@ int RigidEntity::addForceX(float xForce) {
 int RigidEntity::addForceY(float yForce) {
 	force.y += yForce;
 	return 0;
+}
+
+int RigidEntity::testMove(Vector delta) {
+	for (auto element : entityTracker) {
+		if (element.first == Entity::id) continue;
+		if (dynamic_cast<RigidEntity*>(element.second)) {
+			RigidEntity* rigidEntity = dynamic_cast<RigidEntity*>(element.second);
+			SDL_Rect dst1 = { transform.position.x + delta.x, transform.position.y + delta.y, transform.scale.x, transform.scale.y };
+			SDL_Rect dst2 = { rigidEntity->transform.position.x, rigidEntity->transform.position.y, rigidEntity->transform.scale.x, rigidEntity->transform.scale.y };
+			if (SDL_HasIntersection(&dst1, &dst2)) {
+				velocity = (0, 0);
+				return 0;
+			}
+		}
+	}
+	transform.position += delta;
+	return 1;
 }

--- a/feather/rigidentity.h
+++ b/feather/rigidentity.h
@@ -26,6 +26,8 @@ class RigidEntity : public Entity {
 		int addForceX(float x);
 		int addForceY(float Y);
 
+		int testMove(Vector delta);
+
 		int Update(float deltaTime);
 };
 


### PR DESCRIPTION
Right now, the collision is a bit buggy. Visually it looks a bit weird, and objects continue to accelerate despite being collided.
![collision_demo1](https://user-images.githubusercontent.com/62521534/195002236-f8b2ae14-2748-4aa1-9ba3-9862cced54fd.gif)

Added a function that just tests if the next delta*velocity will bring it to an overlap with an entity. Currently it will lose *all* velocity which is not necessarily desirable in all cases (i.e. partially inelastic/elastic collisions). Additionally, it means that entities inside each other will never move, which it should probably have an option to push entities out of each other when this happens. In any case, the physics is a bit improved.
![collision_demo2](https://user-images.githubusercontent.com/62521534/195002511-0823c57b-534f-4996-9f22-44866cbfcecd.gif)
