### PR TITLE
Added hitboxes and a debug mode to show them #41

### DIFF
--- a/example/mouse_game.cpp
+++ b/example/mouse_game.cpp
@@ -11,15 +11,18 @@ vector<RigidEntity*> balls;
 Vector offset;
 
 int cash;
+int mainID;
 
 //Runs on first frame
 void Begin() {
+	drawHitboxes = true;
 	Player.Create("assets/player.png", 0, 0, 128, 128);
-	Player.Clone();
 
 	ball.Create("assets/ball.png", 30, 30, 140, 140);
 	ball.gravity = 0;
+	ball.setHitbox(28, 22, 70, 70);
 	balls.push_back(&ball);
+	mainID = ball.id;
 
 
 	for (int i = 0; i < 5; i++) {
@@ -47,6 +50,13 @@ void Step() {
 	for (int i = 0; i < balls.size(); i++) {
 		if (Player.Collided(*balls[i])) {
 			cash++;
+			if (balls[i]->id == mainID) {
+				for (auto b : balls) b->Destroy();
+				balls.clear();
+				Player.Destroy();
+				Begin();
+				return;
+			}
 			balls[i]->Destroy();
 		}
 		if (balls[i]->transform.position.y >= 970) {

--- a/feather/core.h
+++ b/feather/core.h
@@ -32,6 +32,8 @@ extern double delta;
 
 extern int currentID;
 
+extern bool drawHitboxes;
+
 void Begin();
 void Step();
 void End();

--- a/feather/entity.h
+++ b/feather/entity.h
@@ -25,7 +25,7 @@ class Entity {
 		int swapSprite(const char *spritePath);
 		SDL_Texture* getSprite();
 
-		int Draw();
+		virtual int Draw();
 		int Destroy();
 		virtual int Create(const char *spritePath, int x, int y, int width, int height, double newAngle = 0.0);
 		virtual int Create(const char *spritePath, Vector position, Vector scale, double newAngle = 0.0);

--- a/feather/main.cpp
+++ b/feather/main.cpp
@@ -27,6 +27,9 @@ Uint64 currentFrame = 0;
 
 int currentID;
 std::unordered_map<int, Entity*> entityTracker;
+bool drawHitboxes = false;
+SDL_BlendMode mode = SDL_BLENDMODE_BLEND;
+SDL_BlendMode* alpha = &mode;
 
 View view;
 
@@ -85,7 +88,7 @@ int main(int argc, char **argv){
 		if(event.type == SDL_QUIT){
 			running = false;
 		}
-
+		SDL_SetRenderDrawColor(rend, BG_COLOR[0], BG_COLOR[1], BG_COLOR[2], BG_COLOR[3]);
 		SDL_RenderClear(rend);
 
 		if(!paused){

--- a/feather/main.cpp
+++ b/feather/main.cpp
@@ -28,8 +28,6 @@ Uint64 currentFrame = 0;
 int currentID;
 std::unordered_map<int, Entity*> entityTracker;
 bool drawHitboxes = false;
-SDL_BlendMode mode = SDL_BLENDMODE_BLEND;
-SDL_BlendMode* alpha = &mode;
 
 View view;
 

--- a/feather/rigidentity.cpp
+++ b/feather/rigidentity.cpp
@@ -1,7 +1,7 @@
 #include "rigidentity.h"
 #include <math.h>
 
-using namespace std;
+//using namespace std;
 
 int RigidEntity::Update(float deltaTime) {
 	float time = deltaTime;
@@ -27,10 +27,29 @@ RigidEntity* RigidEntity::Clone() {
 RigidEntity* RigidEntity::Clone(Transform t) {
 	RigidEntity *cloneEntity = new RigidEntity;
 	cloneEntity->Create(this->getSprite(), t);
+	cloneEntity->setHitbox(this->hitbox.x, this->hitbox.y, this->hitbox.w, this->hitbox.h);
 	cloneEntity->setClone();
 	return cloneEntity;
 }
 
+int RigidEntity::Draw() {
+	this->Entity::Draw();
+	if (drawHitboxes && this->isActive()) {
+		SDL_SetRenderDrawBlendMode(rend, SDL_BLENDMODE_BLEND);
+		SDL_SetRenderDrawColor(rend, 0, 255, 0, 100);
+		SDL_Rect target = { (int) transform.position.x + hitbox.x,(int) transform.position.y + hitbox.y, hitbox.w, hitbox.h };
+		SDL_RenderFillRect(rend, &target);
+	}
+	return 0;
+}
+
+int RigidEntity::setHitbox(int x, int y, int w, int h) {
+	hitbox.x = x;
+	hitbox.y = y;
+	hitbox.w = w;
+	hitbox.h = h;
+	return 0;
+}
 
 int RigidEntity::addForce(Vector forceVec) {
 	force.x += forceVec.x;
@@ -53,14 +72,14 @@ int RigidEntity::testMove(Vector delta) {
 		if (element.first == Entity::id) continue;
 		if (dynamic_cast<RigidEntity*>(element.second)) {
 			RigidEntity* rigidEntity = dynamic_cast<RigidEntity*>(element.second);
-			SDL_Rect dst1 = { transform.position.x + delta.x, transform.position.y + delta.y, transform.scale.x, transform.scale.y };
-			SDL_Rect dst2 = { rigidEntity->transform.position.x, rigidEntity->transform.position.y, rigidEntity->transform.scale.x, rigidEntity->transform.scale.y };
+			SDL_Rect dst1 = { (int)(transform.position.x + hitbox.x + delta.x), (int)(transform.position.y + hitbox.y + delta.y), hitbox.w, hitbox.h };
+			SDL_Rect dst2 = { (int)rigidEntity->transform.position.x + rigidEntity->hitbox.x, (int)rigidEntity->transform.position.y + rigidEntity->hitbox.y, rigidEntity->hitbox.w, rigidEntity->hitbox.h };
 			if (SDL_HasIntersection(&dst1, &dst2)) {
 				velocity = (0, 0);
-				return 0;
+				return 1;
 			}
 		}
 	}
 	transform.position += delta;
-	return 1;
+	return 0;
 }

--- a/feather/rigidentity.h
+++ b/feather/rigidentity.h
@@ -7,16 +7,19 @@
 
 class RigidEntity : public Entity {
 	private:
-		bool active = false;
 		SDL_Texture *sprite;
 	public:
 		bool rigid = true;
 
 		RigidEntity* Clone();
 		RigidEntity* Clone(Transform t);
+		int Draw();
 
 		Vector velocity;
 		Vector acceleration;
+
+		SDL_Rect hitbox;
+		int setHitbox(int x = 0, int y = 0, int w = 1, int h = 1);
 
 		float gravity = -9.8;
 		float mass = 1;


### PR DESCRIPTION
Improved hitboxes, and a debug mode:
![hitbox_demo](https://user-images.githubusercontent.com/62521534/195531944-91e4a7fb-c3df-4229-81bc-f67089e9e589.gif)

As of now, the debug mode is just a global that you can set to true. Not sure if this is the best way to do this, let me know if there is something different (maybe a directive, but it would be nice to be able to turn it on and off as you wish in game).

Clone() in RigidEntity now clones the hitbox, and hitboxes can be set via setHitbox().